### PR TITLE
created base-class for scene_operation

### DIFF
--- a/env/includes/settings/tk-desktop.yml
+++ b/env/includes/settings/tk-desktop.yml
@@ -50,5 +50,6 @@ settings.tk-desktop.project:
     - "*Photoshop*"
     - "*After*"
     - "*Effects*"
+    - "*Substance*"
     name: Creative Tools
   location: "@engines.tk-desktop.location"

--- a/env/includes/settings/tk-multi-workfiles2.yml
+++ b/env/includes/settings/tk-multi-workfiles2.yml
@@ -17,9 +17,9 @@ includes:
 
 # common_workfiles_hooks
 common_workfiles_hooks: &common_workfiles_hooks
-  hook_filter_publishes: '{config}/shared/filter_publishes.py'
-  hook_filter_work_files: '{config}/tk-multi-workfiles2/filter_work_files.py'
-  hook_scene_operation: "{config}/tk-multi-workfiles2/scene_operation_{engine_name}.py"
+  hook_filter_publishes: "{config}/shared/filter_publishes.py"
+  hook_filter_work_files: "{config}/tk-multi-workfiles2/filter_work_files.py"
+  hook_scene_operation: "{config}/tk-multi-workfiles2/scene_operation_perforce.py:{config}/tk-multi-workfiles2/scene_operation_{engine_name}.py"
 
 # entity_browser_settings
 entity_browser_settings: &entity_browser_settings

--- a/hooks/tk-multi-workfiles2/scene_operation_perforce.py
+++ b/hooks/tk-multi-workfiles2/scene_operation_perforce.py
@@ -1,0 +1,100 @@
+# This hook can be used as a base class for other scene operations that need
+# perforce actions.
+import os
+
+import sgtk
+from sgtk import TankError, LogManager
+from sgtk.platform.qt import QtGui, QtCore
+
+log = LogManager.get_logger(__name__)
+HookBaseClass = sgtk.get_hook_baseclass()
+TK_FRAMEWORK_PERFORCE_NAME = "tk-framework-perforce_v0.x.x"
+
+
+class SceneOperation(HookBaseClass):
+    """
+    Hook called to perform an operation with the current scene
+    """
+
+    def execute(
+        self,
+        operation,
+        file_path,
+        context,
+        parent_action,
+        file_version,
+        read_only,
+        **kwargs
+    ):
+        """
+        Main hook entry point
+
+        :param operation:       String
+                                Scene operation to perform
+
+        :param file_path:       String
+                                File path to use if the operation
+                                requires it (e.g. open)
+
+        :param context:         Context
+                                The context the file operation is being
+                                performed in.
+
+        :param parent_action:   This is the action that this scene operation is
+                                being executed for.  This can be one of:
+                                - open_file
+                                - new_file
+                                - save_file_as
+                                - version_up
+
+        :param file_version:    The version/revision of the file to be opened.  If this is 'None'
+                                then the latest version should be opened.
+
+        :param read_only:       Specifies if the file should be opened read-only or not
+
+        :returns:               Depends on operation:
+                                'current_path' - Return the current scene
+                                                 file path as a String
+                                'reset'        - True if scene was reset to an empty
+                                                 state, otherwise False
+                                all others     - None
+        """
+        p4_fw = self.load_framework(TK_FRAMEWORK_PERFORCE_NAME)
+        p4 = p4_fw.connection.connect()
+        p4_fw.util = p4_fw.import_module("util")
+        p4_icon = os.path.join(self.disk_location, os.pardir, os.pardir, "icons", "perforce.png")
+
+        if operation == "open":
+            # check if the file is checked out
+            file_details = None
+            try:
+                file_details = p4_fw.util.get_client_file_details(p4, file_path, fields=["action"], flags=[])[file_path]
+                log.debug("file_details: {}".format(file_details))
+            except TankError, e:
+                self.parent.log_warning(e)
+            # check if the file is checked out
+            if not file_details.get("action") == "edit":
+                # if its not checked out, ask before opening
+                msgBox = QtGui.QMessageBox()
+                msgBox.setText("This file is not checked out.")
+                msgBox.setInformativeText("Do you want to check it out before opening in order to make changes?")
+                msgBox.setIconPixmap(QtGui.QPixmap(p4_icon).scaledToWidth(48, QtCore.Qt.SmoothTransformation))
+                msgBox.setStandardButtons(QtGui.QMessageBox.Yes | QtGui.QMessageBox.No)
+                msgBox.setDefaultButton(QtGui.QMessageBox.Yes)
+                msgBox.setEscapeButton(QtGui.QMessageBox.No)
+
+                ret = msgBox.exec_()
+
+                if ret == QtGui.QMessageBox.Yes:
+                    # check out the file
+                    try:
+                        p4_fw.util.open_file_for_edit(p4, file_path, add_if_new=False)
+                    except TankError, e:
+                        self.parent.log_warning(e)
+
+        elif operation == "save_as":
+            # ensure the file is checked out if it's a Perforce file:
+            try:
+                p4_fw.util.open_file_for_edit(p4, file_path, add_if_new=True)
+            except TankError, e:
+                self.parent.log_warning(e)

--- a/hooks/tk-multi-workfiles2/scene_operation_tk-3dsmax.py
+++ b/hooks/tk-multi-workfiles2/scene_operation_tk-3dsmax.py
@@ -13,11 +13,10 @@ import pymxs
 import sgtk
 from sgtk import TankError
 
-HookClass = sgtk.get_hook_baseclass()
-TK_FRAMEWORK_PERFORCE_NAME = "tk-framework-perforce_v0.x.x"
+HookBaseClass = sgtk.get_hook_baseclass()
 
 
-class SceneOperation(HookClass):
+class SceneOperation(HookBaseClass):
     """
     Hook called to perform an operation with the current scene
     """
@@ -65,20 +64,16 @@ class SceneOperation(HookClass):
                                                  state, otherwise False
                                 all others     - None
         """
-        p4_fw = self.load_framework(TK_FRAMEWORK_PERFORCE_NAME)
-        p4_fw.util = p4_fw.import_module("util")
+        # run the base class operations
+        super(SceneOperation, self).execute(operation, file_path, context,
+                                            parent_action, file_version,
+                                            read_only, **kwargs)
 
         if operation == "current_path":
             # return the current scene path or an empty string.
             return _session_path() or ""
 
         elif operation == "open":
-            # check that we have the correct version synced:
-            p4 = p4_fw.connection.connect()
-            if not read_only:
-                # open the file for edit:
-                p4_fw.util.open_file_for_edit(p4, file_path, add_if_new=False)
-
             # open the specified scene
             _open_file(file_path)
 
@@ -87,13 +82,6 @@ class SceneOperation(HookClass):
             _save_file()
 
         elif operation == "save_as":
-            # ensure the file is checked out if it's a Perforce file:
-            try:
-                p4 = p4_fw.connection.connect()
-                p4_fw.util.open_file_for_edit(p4, file_path, add_if_new=False)
-            except TankError, e:
-                self.parent.log_warning(e)
-
             # save the scene as file_path:
             _save_file(file_path)
 


### PR DESCRIPTION
- created a base class for the hook_scene_operation
- all perforce code will go into scene_operation_perforce.py and then be referenced as super by the engine scene operations
- scene_operation_tk-{engine}.py files updated: removed duplicated perforce code, all now execute the base-class prior to running engine specific code.  